### PR TITLE
Adds Index out-of-bound probability option to csmith (#113)

### DIFF
--- a/src/Bookkeeper.cpp
+++ b/src/Bookkeeper.cpp
@@ -91,6 +91,7 @@ int Bookkeeper::forward_jump_cnt = 0;
 int Bookkeeper::backward_jump_cnt = 0;
 int Bookkeeper::use_new_var_cnt = 0;
 int Bookkeeper::use_old_var_cnt = 0;
+int Bookkeeper::oob_cnt = 0;
 bool Bookkeeper::rely_on_int_size = false;
 bool Bookkeeper::rely_on_ptr_size = false;
 
@@ -207,6 +208,7 @@ Bookkeeper::output_statistics(std::ostream &out)
 		out << "FYI: the random generator makes assumptions about the pointer size. See ";
 		out << PLATFORM_CONFIG_FILE << " for more details." << endl;
 	}
+	output_oob_statistics(out);
 }
 
 void
@@ -219,6 +221,12 @@ Bookkeeper::output_struct_union_statistics(std::ostream &out)
 	}
 	formated_output(out, "total union variables: ", union_var_cnt);
 	Bookkeeper::output_bitfields(out);
+}
+
+void
+Bookkeeper::output_oob_statistics(std::ostream &out)
+{
+    formated_output(out, "total OOB instances added: ", oob_cnt);
 }
 
 void

--- a/src/Bookkeeper.h
+++ b/src/Bookkeeper.h
@@ -66,6 +66,8 @@ public:
 	static void output_counters(std::ostream &out, const char* prefix_msg,
 		const char* breakdown_msg, const std::vector<int> &counters, int starting_pos = 0);
 
+	static void output_oob_statistics(std::ostream &out);
+
 	static void update_ptr_aliases(const vector<Fact*>& facts, vector<const Variable*>& ptrs, vector<vector<const Variable*> >& aliases);
 
 	static void record_address_taken(const Variable *var);
@@ -140,6 +142,8 @@ public:
 
 	static int use_new_var_cnt;
 	static int use_old_var_cnt;
+
+	static int oob_cnt;
 
 	static bool rely_on_int_size;
 	static bool rely_on_ptr_size;

--- a/src/CGOptions.cpp
+++ b/src/CGOptions.cpp
@@ -194,6 +194,7 @@ DEFINE_GETTER_SETTER_BOOL(const_struct_union_fields);
 DEFINE_GETTER_SETTER_BOOL(lang_cpp);
 DEFINE_GETTER_SETTER_BOOL(cpp11);
 DEFINE_GETTER_SETTER_BOOL(fast_execution);
+DEFINE_GETTER_SETTER_INT(array_oob_prob);
 
 //GCC C Extensions
 DEFINE_GETTER_SETTER_BOOL(func_attr_flag);
@@ -312,6 +313,7 @@ CGOptions::set_default_settings(void)
 	lang_cpp(false);
 	cpp11(false);
   fast_execution(false);
+	array_oob_prob(0);
 
 	set_default_builtin_kinds();
 	Int128(false);
@@ -532,6 +534,11 @@ CGOptions::has_conflict(void)
 		return true;
 	}
 
+	if ((CGOptions::array_oob_prob() < 0) ||
+	    (CGOptions::array_oob_prob() > 100)) {
+		conflict_msg_ = "array-oob-prob value must between [0,100]";
+		return true;
+	}
 
 	if (CGOptions::max_funcs() < 1) {
 		conflict_msg_ = "max-funcs must be at least 1";

--- a/src/CGOptions.h
+++ b/src/CGOptions.h
@@ -398,6 +398,9 @@ public:
 	static int builtin_function_prob(void);
 	static int builtin_function_prob(int p);
 
+	static int array_oob_prob(void);
+	static int array_oob_prob(int);
+
 	static int null_pointer_dereference_prob(void);
 	static int null_pointer_dereference_prob(int p);
 
@@ -600,6 +603,7 @@ private:
 	static bool force_non_uniform_array_init_;
 	static int inline_function_prob_;
 	static int builtin_function_prob_;
+	static int array_oob_prob_;
 	static int null_pointer_dereference_prob_;
 	static int dead_pointer_dereference_prob_;
 	static bool pre_incr_operator_;

--- a/src/Probabilities.cpp
+++ b/src/Probabilities.cpp
@@ -481,6 +481,9 @@ Probabilities::set_single_name_maps()
 	// for choosing a builtin function
 	set_single_name("builtin_function_prob", pBuiltinFunctionProb);
 
+	// for choosing OOB limit
+    set_single_name("array_oob_prob", pArrayOOBProb);
+
         //////////////////////////////////////////////////////////////////
 	// group for statement
 	set_single_name("statement_prob", pStatementProb);
@@ -619,6 +622,7 @@ Probabilities::initialize_single_probs()
 	m[pAccessOnceVariableProb] = 20;
 	m[pInlineFunctionProb] = CGOptions::inline_function_prob();
 	m[pBuiltinFunctionProb] = CGOptions::builtin_function_prob();
+    m[pArrayOOBProb] = CGOptions::array_oob_prob();
 
 	std::map<ProbName, int>::iterator i;
 	for (i = m.begin(); i != m.end(); ++i) {

--- a/src/Probabilities.h
+++ b/src/Probabilities.h
@@ -65,6 +65,7 @@ enum ProbName {
 	pAccessOnceVariableProb,
 	pInlineFunctionProb,
 	pBuiltinFunctionProb,
+    pArrayOOBProb,
 
 	// group for statement
 	pStatementProb,

--- a/src/RandomProgramGenerator.cpp
+++ b/src/RandomProgramGenerator.cpp
@@ -175,6 +175,7 @@ static void print_help()
 	cout << "  --math64 | --no-math64: enable | disable 64-bit math ops (enabled by default)." << endl << endl;
 	cout << "  --inline-function | --no-inline-function: enable | disable inline attributes on generated functions." << endl << endl;
 	cout << "  --inline-function-prob <num>: set the probability of each function being marked as inline (default is 50)." << endl << endl;
+	cout << "  --array-oob-prob <num>: set the probability for limit of an array accessing loop to be out of bounds (default is 0)." << endl << endl;
 
 	// numbered controls
 	cout << "  --max-array-dim <num>: limit array dimensions to <num>. (default 3)" << endl << endl;
@@ -1272,6 +1273,16 @@ main(int argc, char **argv)
 			if (!parse_int_arg(argv[i], &prob))
 				exit(-1);
 			CGOptions::builtin_function_prob(prob);
+			continue;
+		}
+
+		if (strcmp (argv[i], "--array-oob-prob") == 0 ) {
+			unsigned long prob;
+			i++;
+			arg_check(argc, i);
+			if (!parse_int_arg(argv[i], &prob))
+				exit(-1);
+			CGOptions::array_oob_prob(prob);
 			continue;
 		}
 

--- a/src/StatementFor.cpp
+++ b/src/StatementFor.cpp
@@ -133,10 +133,11 @@ static unsigned int
 make_random_array_control(unsigned int bound, int &init, int &limit, int &incr, eBinaryOps &test_op, eAssignOps &incr_op, bool is_signed)
 {
 	// choose either increment or decrement
+    int oob_flipcoin = pure_rnd_flipcoin(CGOptions::array_oob_prob());
 	test_op = is_signed ? (rnd_flipcoin(50) ? eCmpLe : eCmpGe) : eCmpLe;
 	if (test_op == eCmpLe) {
+        init = oob_flipcoin ? -1000 : pure_rnd_flipcoin(50) ? 0 : pure_rnd_upto(bound/2);
 		// increment, start near index 0
-		init  = pure_rnd_flipcoin(50) ? 0 : pure_rnd_upto(bound/2);
 		limit = bound;
 		incr_op = eAddAssign;
 		incr = pure_rnd_flipcoin(50) ? 1 : pure_rnd_upto(bound/4);
@@ -145,12 +146,13 @@ make_random_array_control(unsigned int bound, int &init, int &limit, int &incr, 
 	} else {
 		// decrement, start near last index
 		init = pure_rnd_flipcoin(50) ? (bound) : (bound - pure_rnd_upto(bound/2));
-		limit = pure_rnd_flipcoin(50) ? 0 : pure_rnd_upto(bound/2);
+        limit = oob_flipcoin ? -1000 : pure_rnd_flipcoin(50) ? 0 : pure_rnd_upto(bound/2);
 		incr_op = eSubAssign;
 		incr = pure_rnd_flipcoin(50) ? 1 : pure_rnd_upto(bound/4);
 		if (incr == 0) incr = 1;
 		bound = init;
 	}
+	Bookkeeper::oob_cnt = oob_flipcoin ? Bookkeeper::oob_cnt +1 : Bookkeeper::oob_cnt;
 	return bound;
 }
 


### PR DESCRIPTION
* Adds Index out-of-bound probability option to csmith
Using the --add-oob-prob flag csmith can be used to generate code
that may result in an index out-of-bound (OOB) situation. This
patch may be helpful in making testcases for utilities used for
performing crash-analysis and fault triage.

* Requested update to PR#113
- The argument is now --array-oob-prob
- Fixed indentation
- Removed unnecessary comments
- Set lower limit (for decrementing loops) and init  (for
incrementing loop). Tests with very low limit and init values only
result in almost endless loops in cases where arrays are not
accessed within these loops. --array-oob-prob has been seen to work
better when used with higher value --max-array-dim argument.

* Add bookkeeping statistics for PR#113

Co-authored-by: Ali Shuja Siddiqui <alissidd@cisco.com>